### PR TITLE
Balloon dm core8 hack

### DIFF
--- a/modules/ftm/ftmx86/.gitignore
+++ b/modules/ftm/ftmx86/.gitignore
@@ -1,0 +1,2 @@
+ftm-ctl
+libftm.a

--- a/modules/ftm/ftmx86/access.c
+++ b/modules/ftm/ftmx86/access.c
@@ -1058,7 +1058,8 @@ uint64_t cpus2thrs(uint32_t cpus) {
   
   for(i=0;i<8;i++) {
     res |= (((cpus >> i) & 1ull) << (i*8));
-  }  
+  }
+  
   return res;
 }
 
@@ -1067,6 +1068,10 @@ uint32_t thrs2cpus(uint64_t thrs) {
   uint64_t res=0;
   
   for(i=0;i<64;i++) res |= (((thrs >> i) & 1) << (i/8));
+  
+  // Hack: This must be core 8
+  if (!res) { res=0x100; }
+  
   return res;
   
 }


### PR DESCRIPTION
I noticed that it is not possible to put a schedule into core 8, thus I wrote a quick hack to perform some tests.

The problem occurs in the function thrs2cpus (access.c):

You put the "CPUID" into a 64bit representation (uint64_t thrs).

```
thrs2cpus gives me the following values:

core id | res |           thrs
---------------------------------------------------------------------
0:           0x1          0x1 
1:           0x2          0x100
...
6:           0x40         0x1000000000000
7:           0x80         0x100000000000000
8:           0x00         0x0 !!! 
```
!!! This will not work out, because it should be 0x100 for res and the 64bit representation for core 8 requires a 128bit value.

You should also check the dump functionality which uses cpus2thrs (access.c)