### PR TITLE
C release fix vetar irq

### DIFF
--- a/syn/gsi_vetar2a/wr_core_demo/vetar2a.qsf
+++ b/syn/gsi_vetar2a/wr_core_demo/vetar2a.qsf
@@ -1006,3 +1006,5 @@ set_global_assignment -name VHDL_FILE "../../../ip_cores/general-cores/modules/g
 set_global_assignment -name VHDL_FILE "../../../ip_cores/general-cores/modules/wishbone/wb_onewire_master/xwb_onewire_master.vhd"
 set_global_assignment -name PRE_FLOW_SCRIPT_FILE "quartus_sh:vetar2a_top.tcl"
 
+
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to vme_iackin_n_i


### PR DESCRIPTION
First commit: Update submodule pointer for vetar2a gateware to latest version.
Second commit: Enable pull-up on IACKIN pin on FPGA. Interrupt acknowledge signal is now forwarded correctly on passive VME backplanes. That will make Interrupts  work even if multiple vetar2a cards are in one crate with passive backplane.

The branch c_release_fix_vetar_irq was tested for working interrupts with runtime /common/export/timing-rte/tg-multi_vetar and three vetar2a cards in a WIENER crate.