### PR TITLE
build: bugfix from a06d2703: preserve buildid

### DIFF
--- a/modules/lm32-include/ram.ld.S
+++ b/modules/lm32-include/ram.ld.S
@@ -24,7 +24,7 @@ SECTIONS
 	_eboot = .;
 
 	.buildid ADDR(.boot) + CONFIG_BOOTSIZE :
-		{ *(.buildid .buildid.*) } > ram
+		{ KEEP(*(.buildid .buildid.*)) } > ram
 
 	_fshared = .;
 	.shared ADDR(.buildid) + CONFIG_BUILDIDSIZE :


### PR DESCRIPTION
When introducing --gc-sections we forced removal of all unreferenced
symbols. But the build-id string is not referenced (it is meant
to be retrieved by external tools). Thus we must force the
linker to keep it.

An alternative would be to mark it as __attribute__((__used__))
in buildid.c, but a linker issue is better fixed at linker level.

Signed-off-by: Alessandro Rubini <rubini@gnudd.com>