### PR TITLE
Eb mon dietrich 2020 jan 15

### DIFF
--- a/tools/monitoring/eb-mon.c
+++ b/tools/monitoring/eb-mon.c
@@ -3,7 +3,7 @@
 //
 //  created : 2015
 //  author  : Dietrich Beck, GSI-Darmstadt
-//  version : 27-nov-2019
+//  version : 15-jan-2020
 //
 // Command-line interface for WR monitoring via Etherbone.
 //
@@ -34,7 +34,7 @@
 // For all questions and ideas contact: d.beck@gsi.de
 // Last update: 25-April-2015
 //////////////////////////////////////////////////////////////////////////////////////////////
-#define EBMON_VERSION "2.0.5"
+#define EBMON_VERSION "2.0.6"
 #define AHEADT       1000000     // data master works ahead of time [ns]
 #define EARLYDT   1000000000     // detection limit for early events [ns]
 
@@ -418,7 +418,7 @@ int main(int argc, char** argv) {
 
   // open Etherbone device and socket
   if ((status = wb_open(devName, &device, &socket)) != EB_OK) {
-    fprintf(stderr, "can't open connection to device %s \n", devName);
+    fprintf(stderr, "can't open connection to device %s (%s) \n", devName, eb_status(status));
     return (1);
   }
   

--- a/tools/wb_api.c
+++ b/tools/wb_api.c
@@ -3,7 +3,7 @@
 //
 //  created : Apr 10, 2013
 //  author  : Dietrich Beck, GSI-Darmstadt
-//  version : 26-Sep-2019
+//  version : 16-Jan-2020
 //
 // Api for wishbone devices for timing receiver nodes. This is not a timing receiver API,
 // but only a temporary solution.
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 // etherbone
 #include <etherbone.h>
@@ -131,6 +132,10 @@ uint8_t wire1_crc8(uint8_t *addr, uint8_t len, uint8_t family )
 eb_status_t wb_open(const char *dev, eb_device_t *device, eb_socket_t *socket)
 {
   eb_status_t status;
+  char        udpLProto[] = "udp/";
+  char        udpHProto[] = "UDP/";
+  short       isUdp;
+  
 
 #ifdef WB_SIMULATE
   *device = EB_NULL;
@@ -141,9 +146,20 @@ eb_status_t wb_open(const char *dev, eb_device_t *device, eb_socket_t *socket)
 
   *device = EB_NULL;
   *socket = EB_NULL;
-  
+
+  // check, if protocol is UDP
+  isUdp = 0;
+  if (strstr(dev, udpLProto)) isUdp = 1;
+  if (strstr(dev, udpHProto)) isUdp = 1;
+
   if ((status = eb_socket_open(EB_ABI_CODE, 0, EB_ADDRX|EB_DATAX, socket)) != EB_OK) return status;
   if ((status = eb_device_open(*socket, dev, EB_ADDRX|EB_DATAX, 2, device)) != EB_OK) return status;
+
+  // if protocol is UDP, then wait for 100ms.
+  // eb_device_open will cause an ARP request
+  // after the return flies through the WRS, the WRS need many milliseconds to learn the nodes MAC address
+  // sleeping intends to give the WRS enough time for MAC address learning; this is a hack!
+  if (isUdp) usleep(100000);
 
   known_sock = *socket;
 

--- a/tools/wb_api.c
+++ b/tools/wb_api.c
@@ -156,10 +156,11 @@ eb_status_t wb_open(const char *dev, eb_device_t *device, eb_socket_t *socket)
   if ((status = eb_device_open(*socket, dev, EB_ADDRX|EB_DATAX, 2, device)) != EB_OK) return status;
 
   // if protocol is UDP, then wait for 100ms.
-  // eb_device_open will cause an ARP request
-  // after the return flies through the WRS, the WRS need many milliseconds to learn the nodes MAC address
-  // sleeping intends to give the WRS enough time for MAC address learning; this is a hack!
-  if (isUdp) usleep(100000);
+  // eb_device_open will (most of the time) cause an ARP request
+  // the answer from the node flies through the WRS, but the WRS need many milliseconds to learn the nodes MAC address
+  // sleeping intends to give the WRS enough time for MAC address learning before we start EB communication to the node
+  // this is a hack!
+  if (isUdp) usleep(200000);
 
   known_sock = *socket;
 

--- a/tools/wb_api.h
+++ b/tools/wb_api.h
@@ -9,9 +9,9 @@
 //            -- Wesley W. Terpstra <w.terpstra@gsi.de>
 //            -- Alessandro Rubini <rubini@gnudd.com>
 //            -- Tomasz Wlostowski <tomasz.wlostowski@cern.ch>
-//  version : 08-Oct-2019
+//  version : 16-Jan-2020
 //
-#define WB_API_VERSION "0.14.1"
+#define WB_API_VERSION "0.14.2"
 //
 // Api for wishbone devices for timing receiver nodes. This is not a timing receiver API.
 // 


### PR DESCRIPTION
eb-mon: more descriptive error message in case eb_open fails

eb-mon/eb-massmon: in case proto is 'UDP' opening a connection to a EB device waits for a short time to all MAC learning in WRS