### PR TITLE
scu_sw and slave_clk_switch: fix diob switching

### DIFF
--- a/modules/aux_functions/slave_clk_switch.vhd
+++ b/modules/aux_functions/slave_clk_switch.vhd
@@ -233,10 +233,12 @@ p_err_latch: process (master_clk, nReset)
         if sys_clk_is_bad = '1' then
           s_sys_clk_is_bad_la <= '1';
         elsif clk_switch_cntrl = '1' then
-          if Data_from_SCUB_LA(0) = '1' and s_sys_clk_is_bad_la = '1' then
+          if Data_from_SCUB_LA(0) = '1' then
+            if s_sys_clk_is_bad_la = '1' then
             -- nur wenn "s_sys_clk_is_bad_la" gesetzt ist, soll es zurueckgesetzt werden, da anschliessend
             -- noch getestet wird, ob auf die sys_clk zurueckgeschaltet werden kann.
-            s_sys_clk_is_bad_la <= '0';
+              s_sys_clk_is_bad_la <= '0';
+            end if;
             if s_sys_clk_deviation = '0' and local_clk_is_running = '1' then
               -- nur wenn die sys_clk in der vorgegebenen Toleranz ist und die pll "sys_clk_or_local_clk"
               -- mit der localen Clock getrieben wird, soll das Umschalten auf sys_clk erlaubt sein.

--- a/top/gsi_scu/fg.c
+++ b/top/gsi_scu/fg.c
@@ -108,7 +108,7 @@ void scan_scu_bus(volatile unsigned short *scub_adr, volatile unsigned int *mil_
       fg_ver        = scub_adr[OFFS(i) + FG1_BASE + FG_VER];
 
       ext_clk_reg = scub_adr[OFFS(i) + SLAVE_EXT_CLK];          //read clk status from slave
-      if (ext_clk_reg & 0x1)
+      if (ext_clk_reg & 0x8)                                    //test for local clk running
         scub_adr[OFFS(i) + SLAVE_EXT_CLK] = 0x1;                //switch clk to sys clk from scu bus
 
       // if slave is a sio3, scan for ifa cards


### PR DESCRIPTION
fixes the clk switch of diob slave cards after an eb-reset