### PR TITLE
dm: lib: fix for bad translation of aligned blocks

### DIFF
--- a/modules/ftm/include/block.h
+++ b/modules/ftm/include/block.h
@@ -24,10 +24,10 @@ public:
     rdIdxIl(0), rdIdxHi(0), rdIdxLo(0), wrIdxIl(0), wrIdxHi(0), wrIdxLo(0) {}
   Block(const Block& src) : Node(src), tPeriod(src.tPeriod), rdIdxIl(src.rdIdxIl), rdIdxHi(src.rdIdxHi), rdIdxLo(src.rdIdxLo), wrIdxIl(src.wrIdxIl), wrIdxHi(src.wrIdxHi), wrIdxLo(src.wrIdxLo) {}
   ~Block()  {};
-  virtual void accept(const VisitorVertexWriter& v)     const override { v.visit(*this); }
-  virtual void accept(const VisitorUploadCrawler& v)    const override { v.visit(*this); }
-  virtual void accept(const VisitorDownloadCrawler& v)  const override { v.visit(*this); }
-  virtual void accept(const VisitorValidation& v)       const override { v.visit(*this); }
+  virtual void accept(const VisitorVertexWriter& v)       const = 0;
+  virtual void accept(const VisitorUploadCrawler& v)      const = 0;
+  virtual void accept(const VisitorDownloadCrawler& v)    const = 0;
+  virtual void accept(const VisitorValidation& v)         const = 0;
 
   void show(void)       const;
   void show(uint32_t cnt, const char* sPrefix)  const;
@@ -58,7 +58,10 @@ public:
     //  std::cout << "BlockFixed Clone " << this->name << "this: " << this << " cpy " << tmp << std::endl;
     return boost::make_shared<BlockFixed>(BlockFixed(*this));
   }
-
+  virtual void accept(const VisitorVertexWriter& v)     const override { v.visit(*this); }
+  virtual void accept(const VisitorUploadCrawler& v)    const override { v.visit(*this); }
+  virtual void accept(const VisitorDownloadCrawler& v)  const override { v.visit(*this); }
+  virtual void accept(const VisitorValidation& v)       const override { v.visit(*this); }
 
 };
 
@@ -76,6 +79,10 @@ public:
     //std::cout << "BlockAlign Clone " << this->name << std::endl;
     return boost::make_shared<BlockAlign>(BlockAlign(*this));
   }
+  virtual void accept(const VisitorVertexWriter& v)     const override { v.visit(*this); }
+  virtual void accept(const VisitorUploadCrawler& v)    const override { v.visit(*this); }
+  virtual void accept(const VisitorDownloadCrawler& v)  const override { v.visit(*this); }
+  virtual void accept(const VisitorValidation& v)       const override { v.visit(*this); }
 };
 
 

--- a/modules/ftm/include/visitorvertexwriter.h
+++ b/modules/ftm/include/visitorvertexwriter.h
@@ -9,6 +9,8 @@ class Node;
 
 class Event;
 class Block;
+class BlockAlign;
+class BlockFixed;
 class Meta;
 
 class Command;
@@ -45,7 +47,8 @@ enum class FormatNum {DEC, HEX, HEX16, HEX32, HEX64, BIT, BOOL};
   public:
     VisitorVertexWriter(std::ostream& out) : out(out) {};
     ~VisitorVertexWriter() {};
-    virtual void visit(const Block& el) const;
+    virtual void visit(const BlockFixed& el) const;
+    virtual void visit(const BlockAlign& el) const;
     virtual void visit(const TimingMsg& el) const;
     virtual void visit(const Flow& el) const;
     virtual void visit(const Switch& el) const;

--- a/modules/ftm/src/dotstr.cpp
+++ b/modules/ftm/src/dotstr.cpp
@@ -206,7 +206,7 @@ namespace DotStr {
       namespace Block {
         const std::string sLookDef       = "shape     = \"rectangle\"";
         const std::string sLookFix       = sLookDef;
-        const std::string sLookAlign     = sLookDef;
+        const std::string sLookAlign     = sLookDef + ", style  = \"dotted\"";
 
 
       }

--- a/modules/ftm/src/visitorvertexwriter.cpp
+++ b/modules/ftm/src/visitorvertexwriter.cpp
@@ -88,16 +88,28 @@ void VisitorVertexWriter::pushStopEyecandy(const Node& el) const {
   if(el.isPatExit()) pushSingle(ec::Node::Base::sLookPatExit);
 }
 
+void VisitorVertexWriter::visit(const BlockAlign& el) const  {
+  pushNodeInfo((Node&)el);
+  pushPair(dnp::Base::sType, dnt::sBlockAlign);
+  pushPair(dnp::Block::sTimePeriod, el.getTPeriod(), FormatNum::DEC);
+  pushMembershipInfo((Node&)el);
+  uint32_t qInfo = (el.getFlags() >> NFLG_BLOCK_QS_POS) & NFLG_BLOCK_QS_MSK;
+  for (unsigned prio=PRIO_LO; prio <= PRIO_IL; prio++) pushPair(dnp::Block::sGenQPrio[prio], (qInfo >> prio) & 1, FormatNum::BOOL);
+  pushSingle(ec::Node::Block::sLookAlign);
+  pushPaintedEyecandy((Node&)el);
+  pushStartEyecandy((Node&)el);
+  pushStopEyecandy((Node&)el);
+  pushEnd();
+}
 
-
-void VisitorVertexWriter::visit(const Block& el) const  {
+void VisitorVertexWriter::visit(const BlockFixed& el) const  {
   pushNodeInfo((Node&)el);
   pushPair(dnp::Base::sType, dnt::sBlock);
   pushPair(dnp::Block::sTimePeriod, el.getTPeriod(), FormatNum::DEC);
   pushMembershipInfo((Node&)el);
   uint32_t qInfo = (el.getFlags() >> NFLG_BLOCK_QS_POS) & NFLG_BLOCK_QS_MSK;
   for (unsigned prio=PRIO_LO; prio <= PRIO_IL; prio++) pushPair(dnp::Block::sGenQPrio[prio], (qInfo >> prio) & 1, FormatNum::BOOL);
-  pushSingle(ec::Node::Block::sLookDef);
+  pushSingle(ec::Node::Block::sLookFix);
   pushPaintedEyecandy((Node&)el);
   pushStartEyecandy((Node&)el);
   pushStopEyecandy((Node&)el);


### PR DESCRIPTION
Very important to carpeDM lib. Prevents the corruption of reused schedule data (what LSA does) by preventing unintentional transformation of aligned blocks to fixed blocks during download from FPGA schedule