### PR TITLE
Daq timestamp inc fix

### DIFF
--- a/modules/daq/daq.vhd
+++ b/modules/daq/daq.vhd
@@ -1470,7 +1470,7 @@ BEGIN
       ELSIF timestamp_cntr = x"1111_1111_1111_1111" then
       timestamp_cntr    <= x"0000_0000_0000_0000";
     ELSE
-        timestamp_cntr    <= std_logic_vector(unsigned(timestamp_cntr) + x"0000_0000_0000_1000");
+        timestamp_cntr    <= std_logic_vector(unsigned(timestamp_cntr) + timestamp_cntr_increment);
       END IF;
 
   END IF;

--- a/modules/daq/daq.vhd
+++ b/modules/daq/daq.vhd
@@ -1,7 +1,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-use IEEE.STD_LOGIC_UNSIGNED.ALL;
 
 use work.genram_pkg.all;
 use work.daq_pkg.all;
@@ -469,7 +468,8 @@ Trigger_Registered_Logic : FOR i IN 1 TO ch_num GENERATE
       IF (Ena_DAQ_Start_pulse(i) = '1' AND Ena_TrigMod(i) = '1') THEN
         Trig_dly_cnt(i) <= Trig_dly_word_Ch (i);      -- initial load
       ELSIF Trig_dly_cnt(i) /= "0000" AND ChRate(i) = '1' AND Wait_for_Trigger(i) = '0' THEN
-        Trig_dly_cnt(i) <= Trig_dly_cnt(i) - 1;       -- count on each tick until zero
+        -- count on each tick until zero
+        Trig_dly_cnt(i) <= std_logic_vector(unsigned(Trig_dly_cnt(i)) - 1);
       ELSE
         NULL;                                         --stay
       END IF;
@@ -720,7 +720,7 @@ DAQ_Descr: for i in 1 to ch_num generate
         DAQ_Descr_cntr(i)      <= (others => '0');
         DAQ_Descr_runs(i)      <='1';
       elsif DAQ_Descr_cntr(i) /= x"8"  and DAQ_Descr_runs(i)='1' then
-        DAQ_Descr_cntr(i)      <= DAQ_Descr_cntr(i) + 1;
+        DAQ_Descr_cntr(i)      <= std_logic_vector(unsigned(DAQ_Descr_cntr(i)) + 1);
         DAQ_Descr_runs(i)      <='1';
       else
         DAQ_Descr_runs(i)      <='0';
@@ -899,7 +899,7 @@ PM_Logic : for I in 1 to ch_num generate
         HiRes_runs(i)         <='1';                                                              --enable HiRes_Counter and wait for Trig_Pulse_HiRes
       elsif Trig_Pulse_HiRes(i) ='1' or  HiRes_trig_cntr(i) /= x"0000" then
         if HiRes_trig_cntr(i) /=    x"0392" then
-          HiRes_trig_cntr(i)  <= HiRes_trig_cntr(i) + 1;
+          HiRes_trig_cntr(i)  <= std_logic_vector(unsigned(HiRes_trig_cntr(i)) + 1);
           HiRes_runs(i)       <='1';
         else
           HiRes_runs(i)       <='0';
@@ -987,7 +987,7 @@ PM_Logic : for I in 1 to ch_num generate
        if PM_Descr_cntr(i) = x"7" then
             PM_Descr_reached_7(i)   <='0';
        end if;
-        PM_Descr_cntr(i)      <= PM_Descr_cntr(i) + 1;
+        PM_Descr_cntr(i)      <= std_logic_vector(unsigned(PM_Descr_cntr(i)) + 1);
         PM_Descr_runs(i)      <='1';
       else
         PM_Descr_runs(i)      <='0';
@@ -1470,7 +1470,7 @@ BEGIN
       ELSIF timestamp_cntr = x"1111_1111_1111_1111" then
       timestamp_cntr    <= x"0000_0000_0000_0000";
     ELSE
-        timestamp_cntr    <= timestamp_cntr + x"0000_0000_0000_1000";
+        timestamp_cntr    <= std_logic_vector(unsigned(timestamp_cntr) + x"0000_0000_0000_1000");
       END IF;
 
   END IF;

--- a/modules/daq/daq_chan_reg_logic.vhd
+++ b/modules/daq/daq_chan_reg_logic.vhd
@@ -1,7 +1,6 @@
 library ieee;  
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-use IEEE.STD_LOGIC_UNSIGNED.ALL;
 
 
 library work;
@@ -33,32 +32,32 @@ generic(
 
 port  (
       -- SCUB interface
-      Adr_from_SCUB_LA:		in		std_logic_vector(15 downto 0);-- latched address from SCU_Bus
-      Data_from_SCUB_LA:	in		std_logic_vector(15 downto 0);-- latched data from SCU_Bus 
-      Ext_Adr_Val:			  in		std_logic;							      -- '1' => "ADR_from_SCUB_LA" is valid
-      Ext_Rd_active:			in		std_logic;							      -- '1' => Rd-Cycle is active
-      Ext_Wr_active:			in		std_logic;							      -- '1' => Rd-Cycle is active      
-      clk_i:						  in		std_logic;							      -- should be the same clk, used by SCU_Bus_Slave
-      nReset:					    in		std_logic;
+      Adr_from_SCUB_LA:  in std_logic_vector(15 downto 0);-- latched address from SCU_Bus
+      Data_from_SCUB_LA: in std_logic_vector(15 downto 0);-- latched data from SCU_Bus
+      Ext_Adr_Val:       in std_logic;                                                            -- '1' => "ADR_from_SCUB_LA" is valid
+      Ext_Rd_active:     in std_logic;                                                            -- '1' => Rd-Cycle is active
+      Ext_Wr_active:     in std_logic;                                                            -- '1' => Rd-Cycle is active
+      clk_i:             in std_logic;                                                            -- should be the same clk, used by SCU_Bus_Slave
+      nReset:            in std_logic;
       
-      PmDat:              in    std_logic_vector(15 downto 0);
-      DaqDat:             in    std_logic_vector(15 downto 0);
-      Ena_PM_rd:          in    std_logic;
-      daq_fifo_word:      in    std_logic_vector (8 downto 0);     
-      pm_fifo_word:       in    std_logic_vector (9 downto 0);
-      version_number:     in    std_logic_vector (15 downto 9);
-      max_ch_cnt:         in    std_logic_vector (15 downto 10);
+      PmDat:             in std_logic_vector(15 downto 0);
+      DaqDat:            in std_logic_vector(15 downto 0);
+      Ena_PM_rd:         in std_logic;
+      daq_fifo_word:     in std_logic_vector (8 downto 0);
+      pm_fifo_word:      in std_logic_vector (9 downto 0);
+      version_number:    in std_logic_vector (15 downto 9);
+      max_ch_cnt:        in std_logic_vector (15 downto 10);
       
-      Rd_Port:            out   std_logic_vector(15 downto 0);
-      user_rd_active:     out   std_logic;
+      Rd_Port:           out std_logic_vector(15 downto 0);
+      user_rd_active:    out std_logic;
       
-      CtrlReg_o:          out   std_logic_vector(15 downto 0);
-      TrigWord_LW_o :     out   std_logic_vector(15 downto 0);
-      TrigWord_HW_o:      out   std_logic_vector(15 downto 0);
-      Trig_dly_word_o:    out   std_logic_vector(15 downto 0);
-      rd_PMDat:           out   std_logic;      
-      rd_DAQDat:          out   std_logic;
-      dtack :             out   std_logic
+      CtrlReg_o:         out std_logic_vector(15 downto 0);
+      TrigWord_LW_o :    out std_logic_vector(15 downto 0);
+      TrigWord_HW_o:     out std_logic_vector(15 downto 0);
+      Trig_dly_word_o:   out std_logic_vector(15 downto 0);
+      rd_PMDat:          out std_logic;
+      rd_DAQDat:         out std_logic;
+      dtack :            out std_logic
            
     );
 end daq_chan_reg_logic;

--- a/modules/daq/daq_chan_reg_logic.vhd
+++ b/modules/daq/daq_chan_reg_logic.vhd
@@ -1,4 +1,4 @@
-library ieee;  
+library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
@@ -9,10 +9,10 @@ use work.daq_pkg.all;
 
 
 ------------------------------------------------------------------------------------------------------------------------------------
---  Vers: 0 Revi: 0: 2016Sep27 K.Kaiser Initial Version  
---          Revi: 1: 2018Okt20 K.Kaiser Version Number added 
+--  Vers: 0 Revi: 0: 2016Sep27 K.Kaiser Initial Version
+--          Revi: 1: 2018Okt20 K.Kaiser Version Number added
 --  This entity is to be used in a for-generate loop
---  PMDat and DaqDat are read-only by conception 
+--  PMDat and DaqDat are read-only by conception
 --  Rd_Ports are or-ed on level above to concentrate RD Bus
 ------------------------------------------------------------------------------------------------------------------------------------
 
@@ -39,7 +39,7 @@ port  (
       Ext_Wr_active:     in std_logic;                                                            -- '1' => Rd-Cycle is active
       clk_i:             in std_logic;                                                            -- should be the same clk, used by SCU_Bus_Slave
       nReset:            in std_logic;
-      
+
       PmDat:             in std_logic_vector(15 downto 0);
       DaqDat:            in std_logic_vector(15 downto 0);
       Ena_PM_rd:         in std_logic;
@@ -47,10 +47,10 @@ port  (
       pm_fifo_word:      in std_logic_vector (9 downto 0);
       version_number:    in std_logic_vector (15 downto 9);
       max_ch_cnt:        in std_logic_vector (15 downto 10);
-      
+
       Rd_Port:           out std_logic_vector(15 downto 0);
       user_rd_active:    out std_logic;
-      
+
       CtrlReg_o:         out std_logic_vector(15 downto 0);
       TrigWord_LW_o :    out std_logic_vector(15 downto 0);
       TrigWord_HW_o:     out std_logic_vector(15 downto 0);
@@ -58,7 +58,7 @@ port  (
       rd_PMDat:          out std_logic;
       rd_DAQDat:         out std_logic;
       dtack :            out std_logic
-           
+
     );
 end daq_chan_reg_logic;
 
@@ -90,126 +90,126 @@ TrigWord_LW_o   <= TrigWord_LW;
 TrigWord_HW_o   <= TrigWord_HW;
 Trig_dly_word_o <= Trig_dly_word;
 
-  
+
 adr_decoder: process (clk_i, nReset)
   begin
     if nReset = '0' then
       rd_PMDat_int          <= '0';
-      rd_DAQDat_int         <= '0';  
+      rd_DAQDat_int         <= '0';
       rd_DAQ_FIFO_Word      <= '0';
       rd_PM_FIFO_Word       <= '0';
       wr_CtrlReg            <= '0';
       wr_trig_lw            <= '0';
-      wr_trig_hw            <= '0';      
-      wr_Trig_dly_word      <= '0'; 
+      wr_trig_hw            <= '0';
+      wr_Trig_dly_word      <= '0';
       rd_CtrlReg            <= '0';
       rd_trig_lw            <= '0';
-      rd_trig_hw            <= '0';      
-      rd_Trig_dly_word      <= '0';       
-      
+      rd_trig_hw            <= '0';
+      rd_Trig_dly_word      <= '0';
+
     elsif rising_edge(clk_i) then
       rd_PMDat_int          <= '0';
       rd_DAQDat_int         <= '0';
       rd_DAQ_FIFO_Word      <= '0';
       rd_PM_FIFO_Word       <= '0';
-      
+
       wr_CtrlReg            <= '0';
       wr_trig_lw            <= '0';
-      wr_trig_hw            <= '0';      
-      wr_Trig_dly_word      <= '0'; 
+      wr_trig_hw            <= '0';
+      wr_Trig_dly_word      <= '0';
       rd_CtrlReg            <= '0';
       rd_trig_lw            <= '0';
-      rd_trig_hw            <= '0';      
-      rd_Trig_dly_word      <= '0'; 
-      
+      rd_trig_hw            <= '0';
+      rd_Trig_dly_word      <= '0';
+
       if Ext_Adr_Val = '1' then
         case unsigned(Adr_from_SCUB_LA) is
 
-          when PmDat_adr =>  
+          when PmDat_adr =>
             if Ext_Rd_active =  '1' then
               rd_PMDat_int   <= '1';
             end if;
-            
-          when DaqDat_adr =>  
+
+          when DaqDat_adr =>
             if Ext_Rd_active =  '1' then
               rd_DAQDat_int  <= '1';
-            end if;  
-            
-          when DAQ_FIFO_Words_adr =>  
+            end if;
+
+          when DAQ_FIFO_Words_adr =>
             if Ext_Rd_active =  '1' then
               rd_DAQ_FIFO_Word  <= '1';
-            end if;      
-            
-          when PM_FIFO_Words_adr =>  
+            end if;
+
+          when PM_FIFO_Words_adr =>
             if Ext_Rd_active =  '1' then
               rd_PM_FIFO_Word  <= '1';
-            end if;            
+            end if;
 
-           when CtrlReg_adr =>  
+           when CtrlReg_adr =>
             if   Ext_Wr_active = '1' then
               wr_CtrlReg       <= '1';
             elsif Ext_rd_active ='1' then
               rd_CtrlReg       <= '1';
            end if;
 
-          when trig_lw_adr =>  
+          when trig_lw_adr =>
             if Ext_Wr_active = '1' then
               wr_trig_lw       <= '1';
             elsif Ext_rd_active ='1' then
-              rd_trig_lw       <= '1';            
+              rd_trig_lw       <= '1';
             end if;
-            
-          when trig_hw_adr =>  
+
+          when trig_hw_adr =>
             if Ext_Wr_active = '1' then
               wr_trig_hw       <= '1';
             elsif Ext_rd_active ='1' then
               rd_trig_hw       <= '1';
             end if;
- 
-          when trig_dly_word_adr =>  
+
+          when trig_dly_word_adr =>
             if Ext_Wr_active = '1' then
               wr_trig_dly_word    <= '1';
             elsif Ext_rd_active ='1' then
-              rd_trig_dly_word    <= '1';            
-            end if;           
-            
-            
-            
+              rd_trig_dly_word    <= '1';
+            end if;
+
+
+
           when others =>
-        
+
             rd_PMDat_int     <= '0';
             rd_DAQDat_int    <= '0';
             rd_DAQ_FIFO_Word <= '0';
             rd_PM_FIFO_Word  <= '0';
-            
+
             wr_CtrlReg          <= '0';
             wr_trig_lw          <= '0';
-            wr_trig_hw          <= '0';        
-            wr_Trig_dly_word    <= '0'; 
+            wr_trig_hw          <= '0';
+            wr_Trig_dly_word    <= '0';
             rd_CtrlReg          <= '0';
             rd_trig_lw          <= '0';
-            rd_trig_hw          <= '0';        
-            rd_Trig_dly_word    <= '0'; 
-                 
+            rd_trig_hw          <= '0';
+            rd_Trig_dly_word    <= '0';
+
         end case;
       end if;
     end if;
-    
+
   end process adr_decoder;
-  
+
   write2regs: process (clk_i, nReset)
 begin
   if nReset = '0' then
     CtrlReg            <= (others => '0');
     TrigWord_LW        <= (others => '0');
     TrigWord_HW        <= (others => '0');
-    trig_dly_word      <= (others => '0'); 
+    trig_dly_word      <= (others => '0');
   elsif rising_edge(clk_i) then
-  
+
     if wr_CtrlReg = '1' then
       CtrlReg          <= Data_from_SCUB_LA;
     end if;
-    
+
     if wr_trig_lw = '1' then
       TrigWord_LW      <= Data_from_SCUB_LA;
     end if;
@@ -217,33 +217,33 @@ begin
     if wr_trig_hw = '1' then
       TrigWord_HW      <= Data_from_SCUB_LA;
     end if;
- 
+
     if wr_trig_dly_word = '1' then
       Trig_dly_word    <= Data_from_SCUB_LA;
     end if;
 
   end if;
 end process write2regs;
-  
-  
+
+
 rd_PMDat        <= rd_PMDat_int;   -- to trigger fifo read-outs on level above
 rd_DAQDat       <= rd_DAQDat_int;
 
 Rd_Port         <= pmdat                          when rd_PMDat_int     ='1'  and Ena_PM_rd ='1'  else  -- PM Fifo data only valid on stopped PM/Hires DAQ
-                   daqdat                         when rd_DAQDat_int    ='1'                      else  -- all channel Rd Port or-ed on level above      
+                   daqdat                         when rd_DAQDat_int    ='1'                      else  -- all channel Rd Port or-ed on level above
                    max_ch_cnt  & pm_fifo_word     when rd_PM_FIFO_Word  ='1'                      else
                    version_number & daq_fifo_word when rd_DAQ_FIFO_Word ='1'                      else
-                   CtrlReg                        when rd_CtrlReg       ='1'                      else  
-                   TrigWord_LW                    when rd_trig_lw       ='1'                      else       
+                   CtrlReg                        when rd_CtrlReg       ='1'                      else
+                   TrigWord_LW                    when rd_trig_lw       ='1'                      else
                    TrigWord_HW                    when rd_trig_hw       ='1'                      else
                    Trig_dly_word                  when rd_trig_dly_word ='1'                      else
                    x"0000";
 
 user_rd_active  <=    rd_PMDat_int  or rd_DAQDat_int  or rd_PM_FIFO_Word or rd_DAQ_FIFO_Word  or
-                      rd_CtrlReg    or rd_trig_lw     or rd_trig_hw      or rd_trig_dly_word     ;      -- all channel user_rd_actives or-ed on level above 
-                      
+                      rd_CtrlReg    or rd_trig_lw     or rd_trig_hw      or rd_trig_dly_word     ;      -- all channel user_rd_actives or-ed on level above
+
 dtack           <=    rd_PMDat_int  or rd_DAQDat_int  or rd_PM_FIFO_Word or rd_DAQ_FIFO_Word  or
-                      wr_CtrlReg    or wr_trig_lw     or wr_trig_hw      or wr_trig_dly_word  or 
-                      rd_CtrlReg    or rd_trig_lw     or rd_trig_hw      or rd_trig_dly_word     ;  
+                      wr_CtrlReg    or wr_trig_lw     or wr_trig_hw      or wr_trig_dly_word  or
+                      rd_CtrlReg    or rd_trig_lw     or rd_trig_hw      or rd_trig_dly_word     ;
 
 end architecture daq_chan_reg_logic_arch;


### PR DESCRIPTION
fix for the daq macro for SCU bus slaves. used by platforms addac2, addac and diob.