### PR TITLE
simple-display: add new target to install the built executable file

### DIFF
--- a/tools/display/Makefile
+++ b/tools/display/Makefile
@@ -25,7 +25,10 @@ all: simple-display
 simple-display: $(SOURCES)
 	$(CC) $(CFLAGS) $(WCFLAGS) $(DEFINE) -o $@ $^ $(LIBS) -I../../modules/oled_display
 
-clean:  rm -f $(TARGETS)
+install:
+	cp $(TARGETS) $(STAGING)$(PREFIX)/bin
+clean:
+	rm -f $(TARGETS)
 # =================================================================================================
 # END OF ASL DEPLOYMENT
 # =================================================================================================


### PR DESCRIPTION
apply this commit also into the actual release branch 'fallout-v6.3.0' to support the RTE build steps