### PR TITLE
scu4.1: all pin changes for scu4.1

### DIFF
--- a/syn/gsi_scu/slim4/scu4slim.qsf
+++ b/syn/gsi_scu/slim4/scu4slim.qsf
@@ -1,4 +1,3 @@
-
 set_global_assignment -name ACTIVE_SERIAL_CLOCK FREQ_100MHZ
 set_global_assignment -name ADV_NETLIST_OPT_SYNTH_WYSIWYG_REMAP OFF
 set_global_assignment -name AHDL_FILE ../../../modules/modulbus/i2c.tdf
@@ -682,6 +681,8 @@ set_global_assignment -name VHDL_FILE ../../../modules/eca_tap/eca_tap_auto_pkg.
 set_global_assignment -name VHDL_FILE ../../../modules/eca_tap/eca_tap_auto.vhd -library work
 set_global_assignment -name VHDL_FILE ../../../modules/eca_tap/eca_tap_pkg.vhd -library work
 set_global_assignment -name VHDL_FILE ../../../modules/eca_tap/eca_tap.vhd -library work
+set_global_assignment -name VHDL_FILE ../../../modules/enc_err_counter/enc_err_counter_pkg.vhd -library work
+set_global_assignment -name VHDL_FILE ../../../modules/enc_err_counter/enc_err_counter.vhd -library work
 set_global_assignment -name VHDL_FILE ../../../modules/flash_loader/flash_loader_v01.vhd -library work
 set_global_assignment -name VHDL_FILE ../../../modules/ftm/ftm_lm32_cluster.vhd -library work
 set_global_assignment -name VHDL_FILE ../../../modules/ftm/ftm_lm32.vhd -library work
@@ -956,6 +957,7 @@ set_location_assignment PIN_A24 -to clk_125m_pllref_i
 set_location_assignment PIN_A26 -to fpga_res_i
 set_location_assignment PIN_A27 -to rear_in[1]
 set_location_assignment PIN_A2 -to psram_a[17]
+set_location_assignment PIN_A3 -to psram_ubn[3]
 set_location_assignment PIN_A4 -to psram_a[3]
 set_location_assignment PIN_A6 -to psram_dq[8]
 set_location_assignment PIN_A7 -to psram_dq[1]
@@ -1069,7 +1071,7 @@ set_location_assignment PIN_B23 -to onewire_ext_splz
 set_location_assignment PIN_B24 -to pa[3]
 set_location_assignment PIN_B25 -to nSel_Ext_Data_DRV
 set_location_assignment PIN_B26 -to pa[2]
-set_location_assignment PIN_B3 -to psram_ubn
+set_location_assignment PIN_B3 -to psram_ubn[0]
 set_location_assignment PIN_B4 -to psram_a[9]
 set_location_assignment PIN_B5 -to psram_cen[2]
 set_location_assignment PIN_B6 -to psram_dq[4]
@@ -1085,6 +1087,7 @@ set_location_assignment PIN_C21 -to A_OneWire
 set_location_assignment PIN_C22 -to A_Spare[1]
 set_location_assignment PIN_C23 -to A_Spare[0]
 set_location_assignment PIN_C2 -to psram_a[11]
+set_location_assignment PIN_C3 -to psram_ubn[2]
 set_location_assignment PIN_C5 -to psram_dq[5]
 set_location_assignment PIN_C6 -to psram_dq[11]
 set_location_assignment PIN_C7 -to clk_125m_pllref_alt_i
@@ -1097,17 +1100,19 @@ set_location_assignment PIN_D20 -to serial_cb_out[0]
 set_location_assignment PIN_D22 -to A_nSEL[8]
 set_location_assignment PIN_D23 -to A_nSEL[4]
 set_location_assignment PIN_D2 -to psram_a[22]
+set_location_assignment PIN_D3 -to psram_wen[1]
 set_location_assignment PIN_D4 -to psram_a[6]
 set_location_assignment PIN_D5 -to psram_dq[6]
 set_location_assignment PIN_D7 -to "clk_125m_pllref_alt_i(n)"
 set_location_assignment PIN_D8 -to avr_sda
 set_location_assignment PIN_E14 -to pa[6]
 set_location_assignment PIN_E15 -to "clk_125m_local_i(n)"
-set_location_assignment PIN_E1 -to psram_wen
+set_location_assignment PIN_E1 -to psram_wen[0]
 set_location_assignment PIN_E21 -to A_nSEL[6]
 set_location_assignment PIN_E22 -to A_nReset
 set_location_assignment PIN_E23 -to A_SysClock
 set_location_assignment PIN_E2 -to psram_a[2]
+set_location_assignment PIN_E4 -to psram_lbn[3]
 set_location_assignment PIN_E5 -to psram_dq[12]
 set_location_assignment PIN_E6 -to psram_dq[15]
 set_location_assignment PIN_E7 -to psram_dq[7]
@@ -1116,7 +1121,8 @@ set_location_assignment PIN_F18 -to A_nDtack
 set_location_assignment PIN_F1 -to psram_a[1]
 set_location_assignment PIN_F21 -to A_D[8]
 set_location_assignment PIN_F22 -to A_nSEL[5]
-set_location_assignment PIN_F2 -to psram_advn
+set_location_assignment PIN_F2 -to psram_advn[0]
+set_location_assignment PIN_F3 -to psram_wait[1]
 set_location_assignment PIN_F4 -to psram_a[0]
 set_location_assignment PIN_F6 -to psram_cen[0]
 set_location_assignment PIN_F7 -to psram_dq[2]
@@ -1129,7 +1135,9 @@ set_location_assignment PIN_G21 -to A_nSEL[7]
 set_location_assignment PIN_G23 -to clk_20m_vcxo_i
 set_location_assignment PIN_G3 -to psram_a[14]
 set_location_assignment PIN_G4 -to psram_a[16]
-set_location_assignment PIN_G8 -to psram_oen
+set_location_assignment PIN_G5 -to psram_cre[2]
+set_location_assignment PIN_G6 -to psram_cre[3]
+set_location_assignment PIN_G8 -to psram_oen[0]
 set_location_assignment PIN_G9 -to psram_cen[1]
 set_location_assignment PIN_H16 -to A_D[10]
 set_location_assignment PIN_H17 -to A_nSRQ[3]
@@ -1138,8 +1146,9 @@ set_location_assignment PIN_H1 -to user_led_0[2]
 set_location_assignment PIN_H20 -to A_nSRQ[1]
 set_location_assignment PIN_H21 -to A_nDS
 set_location_assignment PIN_H22 -to A_nSRQ[6]
+set_location_assignment PIN_H2 -to debug_led[5]
 set_location_assignment PIN_H3 -to psram_a[21]
-set_location_assignment PIN_H5 -to psram_cre
+set_location_assignment PIN_H5 -to psram_cre[0]
 set_location_assignment PIN_H6 -to psram_a[10]
 set_location_assignment PIN_H7 -to psram_a[23]
 set_location_assignment PIN_H8 -to psram_dq[3]
@@ -1149,11 +1158,15 @@ set_location_assignment PIN_J19 -to A_nSEL[1]
 set_location_assignment PIN_J20 -to A_D[9]
 set_location_assignment PIN_J22 -to A_D[11]
 set_location_assignment PIN_J2 -to scu_cb_version[1]
+set_location_assignment PIN_J3 -to debug_led[1]
+set_location_assignment PIN_J4 -to psram_lbn[2]
 set_location_assignment PIN_J5 -to psram_a[15]
+set_location_assignment PIN_J7 -to psram_wait[2]
 set_location_assignment PIN_J8 -to psram_dq[9]
 set_location_assignment PIN_J9 -to psram_dq[10]
 set_location_assignment PIN_K17 -to A_nTiming_Cycle
 set_location_assignment PIN_K19 -to A_nSRQ[7]
+set_location_assignment PIN_K1 -to psram_advn[3]
 set_location_assignment PIN_K20 -to A_nSRQ[8]
 set_location_assignment PIN_K21 -to A_D[15]
 set_location_assignment PIN_K22 -to A_nSEL[3]
@@ -1161,14 +1174,18 @@ set_location_assignment PIN_K23 -to A_nSEL[2]
 set_location_assignment PIN_K4 -to fd[4]
 set_location_assignment PIN_K5 -to psram_a[8]
 set_location_assignment PIN_K6 -to psram_a[13]
+set_location_assignment PIN_K7 -to psram_ubn[1]
 set_location_assignment PIN_K9 -to psram_dq[0]
 set_location_assignment PIN_L1 -to sfp_los_i
 set_location_assignment PIN_L6 -to psram_a[19]
+set_location_assignment PIN_L7 -to psram_wait[3]
 set_location_assignment PIN_L8 -to psram_dq[13]
 set_location_assignment PIN_L9 -to psram_dq[14]
 set_location_assignment PIN_M25 -to "pcie_rx_i[3](n)"
 set_location_assignment PIN_M26 -to pcie_rx_i[3]
 set_location_assignment PIN_M3 -to nTHRMTRIP
+set_location_assignment PIN_M4 -to psram_cre[1]
+set_location_assignment PIN_M5 -to psram_oen[3]
 set_location_assignment PIN_M6 -to psram_a[4]
 set_location_assignment PIN_M8 -to psram_a[18]
 set_location_assignment PIN_N1 -to clk_20m_vcxo_alt_i
@@ -1177,42 +1194,53 @@ set_location_assignment PIN_N24 -to pcie_refclk_i
 set_location_assignment PIN_N27 -to "pcie_tx_o[3](n)"
 set_location_assignment PIN_N28 -to pcie_tx_o[3]
 set_location_assignment PIN_N2 -to scu_cb_version[3]
-set_location_assignment PIN_N5 -to clk_125m_sfpref_i
-set_location_assignment PIN_N6 -to psram_lbn
+set_location_assignment PIN_N3 -to debug_led[7]
+set_location_assignment PIN_N5 -to psram_oen[2]
+set_location_assignment PIN_N6 -to psram_lbn[0]
+set_location_assignment PIN_N7 -to psram_wen[2]
+set_location_assignment PIN_N8 -to psram_lbn[1]
 set_location_assignment PIN_P25 -to "pcie_rx_i[2](n)"
 set_location_assignment PIN_P26 -to pcie_rx_i[2]
 set_location_assignment PIN_P2 -to scu_cb_version[0]
 set_location_assignment PIN_P3 -to fd[7]
 set_location_assignment PIN_P4 -to scu_cb_version[2]
-set_location_assignment PIN_P5 -to "clk_125m_sfpref_i(n)"
-set_location_assignment PIN_P7 -to psram_wait
+set_location_assignment PIN_P5 -to psram_oen[1]
+set_location_assignment PIN_P7 -to psram_wait[0]
 set_location_assignment PIN_P8 -to psram_a[5]
+set_location_assignment PIN_P9 -to psram_wen[3]
 set_location_assignment PIN_R23 -to "clk_125m_tcb_local_i(n)"
 set_location_assignment PIN_R24 -to clk_125m_tcb_local_i
 set_location_assignment PIN_R27 -to "pcie_tx_o[2](n)"
 set_location_assignment PIN_R28 -to pcie_tx_o[2]
 set_location_assignment PIN_R4 -to sfp_mod0_i
+set_location_assignment PIN_R5 -to sfp_rate_sel_o
 set_location_assignment PIN_R6 -to psram_a[7]
 set_location_assignment PIN_R7 -to psram_a[20]
 set_location_assignment PIN_T1 -to fd[6]
 set_location_assignment PIN_T25 -to "pcie_rx_i[1](n)"
 set_location_assignment PIN_T26 -to pcie_rx_i[1]
+set_location_assignment PIN_T2 -to debug_led[4]
 set_location_assignment PIN_T4 -to sfp_tx_fault_i
 set_location_assignment PIN_T6 -to fd[1]
 set_location_assignment PIN_T7 -to fd[2]
 set_location_assignment PIN_T8 -to WDT
 set_location_assignment PIN_T9 -to fd[5]
+set_location_assignment PIN_U1 -to debug_led[0]
 set_location_assignment PIN_U23 -to "clk_125m_tcb_pllref_i(n)"
 set_location_assignment PIN_U24 -to clk_125m_tcb_pllref_i
 set_location_assignment PIN_U27 -to "pcie_tx_o[1](n)"
 set_location_assignment PIN_U28 -to pcie_tx_o[1]
 set_location_assignment PIN_U3 -to sfp_mod2_io
+set_location_assignment PIN_U4 -to psram_advn[1]
 set_location_assignment PIN_U5 -to fd[3]
 set_location_assignment PIN_U6 -to wr_rgb_led[0]
+set_location_assignment PIN_V1 -to debug_led[3]
 set_location_assignment PIN_V25 -to "pcie_rx_i[0](n)"
 set_location_assignment PIN_V26 -to pcie_rx_i[0]
 set_location_assignment PIN_V2 -to user_led_0[1]
 set_location_assignment PIN_V3 -to sfp_mod1_io
+set_location_assignment PIN_V5 -to debug_led[6]
+set_location_assignment PIN_V6 -to psram_advn[2]
 set_location_assignment PIN_V7 -to wr_rgb_led[2]
 set_location_assignment PIN_V8 -to fd[0]
 set_location_assignment PIN_W10 -to altera_reserved_tdo
@@ -1221,6 +1249,7 @@ set_location_assignment PIN_W23 -to "clk_125m_tcb_sfpref_i(n)"
 set_location_assignment PIN_W24 -to clk_125m_tcb_sfpref_i
 set_location_assignment PIN_W27 -to "pcie_tx_o[0](n)"
 set_location_assignment PIN_W28 -to pcie_tx_o[0]
+set_location_assignment PIN_W2 -to debug_led[2]
 set_location_assignment PIN_W3 -to sfp_tx_disable_o
 set_location_assignment PIN_W4 -to user_led_0[0]
 set_location_assignment PIN_W7 -to wr_dac_din_o

--- a/top/gsi_scu/slim4/scu4slim.vhd
+++ b/top/gsi_scu/slim4/scu4slim.vhd
@@ -126,6 +126,7 @@ entity scu4slim is
     user_led_0 : out std_logic_vector(2 downto 0) := (others => '1');
     wr_rgb_led : out std_logic_vector(2 downto 0) := (others => '1');
     lemo_led   : out std_logic_vector(5 downto 0) := (others => '1');
+    debug_led  : out std_logic_vector(7 downto 0) := (others => '1');
 
     -----------------------------------------------------------------------
     -- Pseudo-SRAM (4x 256Mbit)
@@ -133,14 +134,14 @@ entity scu4slim is
     psram_a    : out   std_logic_vector(23 downto 0) := (others => 'Z');
     psram_dq   : inout std_logic_vector(15 downto 0) := (others => 'Z');
     psram_clk  : out   std_logic := 'Z';
-    psram_advn : out   std_logic := 'Z';
-    psram_cre  : out   std_logic := 'Z';
+    psram_advn : out   std_logic_vector(3 downto 0) := (others => '1');
+    psram_cre  : out   std_logic_vector(3 downto 0) := (others => '1');
     psram_cen  : out   std_logic_vector(3 downto 0) := (others => '1');
-    psram_oen  : out   std_logic := 'Z';
-    psram_wen  : out   std_logic := 'Z';
-    psram_ubn  : out   std_logic := 'Z';
-    psram_lbn  : out   std_logic := 'Z';
-    psram_wait : in    std_logic; -- DDR magic
+    psram_oen  : out   std_logic_vector(3 downto 0) := (others => '1');
+    psram_wen  : out   std_logic_vector(3 downto 0) := (others => '1');
+    psram_ubn  : out   std_logic_vector(3 downto 0) := (others => '1');
+    psram_lbn  : out   std_logic_vector(3 downto 0) := (others => '1');
+    psram_wait : in    std_logic_vector (3 downto 0); -- DDR magic
 
     -----------------------------------------------------------------------
     -- SPI Flash User Mode
@@ -161,7 +162,8 @@ entity scu4slim is
     sfp_rxp_i        : in    std_logic;
     sfp_mod0_i       : in    std_logic;
     sfp_mod1_io      : inout std_logic;
-    sfp_mod2_io      : inout std_logic);
+    sfp_mod2_io      : inout std_logic;
+    sfp_rate_sel_o   : out   std_logic);
 
 end scu4slim;
 
@@ -197,6 +199,13 @@ architecture rtl of scu4slim is
   signal s_core_clk_25m     : std_logic;
 
   signal s_psram_cen        : std_logic;
+  signal s_psram_cre        : std_logic;
+  signal s_psram_advn       : std_logic;
+  signal s_psram_oen        : std_logic;
+  signal s_psram_wen        : std_logic;
+  signal s_psram_ubn        : std_logic;
+  signal s_psram_lbn        : std_logic;
+  
   signal s_psram_sel        : std_logic_vector(3 downto 0);
 
   signal rstn_ref           : std_logic;
@@ -336,22 +345,27 @@ begin
       ps_clk                  => psram_clk,
       ps_addr                 => psram_a,
       ps_data                 => psram_dq,
-      ps_seln(0)              => psram_lbn,
-      ps_seln(1)              => psram_ubn,
+      ps_seln(0)              => s_psram_lbn,
+      ps_seln(1)              => s_psram_ubn,
       ps_cen                  => s_psram_cen,
-      ps_oen                  => psram_oen,
-      ps_wen                  => psram_wen,
-      ps_cre                  => psram_cre,
-      ps_advn                 => psram_advn,
-      ps_wait                 => psram_wait,
+      ps_oen                  => s_psram_oen,
+      ps_wen                  => s_psram_wen,
+      ps_cre                  => s_psram_cre,
+      ps_advn                 => s_psram_advn,
+      ps_wait                 => psram_wait(0) or psram_wait(1) or psram_wait(2) or psram_wait(3),
       ps_chip_selector        => s_psram_sel,
       hw_version              => x"0000000" & not scu_cb_version);
 
   -- PSRAM -> This needs to be changed on the next revision
-  psram_cen(0) <= s_psram_cen when (s_psram_sel(0) = '1') else '1';
-  psram_cen(1) <= s_psram_cen when (s_psram_sel(1) = '1') else '1';
-  psram_cen(2) <= s_psram_cen when (s_psram_sel(2) = '1') else '1';
-  psram_cen(3) <= s_psram_cen when (s_psram_sel(3) = '1') else '1';
+  psram_sel : for i in 0 to 3 generate
+  psram_cen(i)  <= s_psram_cen when  (s_psram_sel(i) = '1') else '1';
+  psram_cre(i)  <= s_psram_cre when  (s_psram_sel(i) = '1') else '1';
+  psram_oen(i)  <= s_psram_oen when  (s_psram_sel(i) = '1') else '1';
+  psram_wen(i)  <= s_psram_wen when  (s_psram_sel(i) = '1') else '1';
+  psram_lbn(i)  <= s_psram_lbn when  (s_psram_sel(i) = '1') else '1';
+  psram_ubn(i)  <= s_psram_ubn when  (s_psram_sel(i) = '1') else '1';
+  psram_advn(i) <= s_psram_advn when (s_psram_sel(i) = '1') else '1';
+end generate;
 
   -- LEDs
   wr_led_pps    <= s_led_pps;                                             -- white = PPS
@@ -407,5 +421,7 @@ begin
   nADR_EN     <= '0';
   A_Spare     <= (others => 'Z');
   --A_OneWire   <= 'Z';
+
+  sfp_rate_sel_o <= '1'; --SFP rate full speed
 
 end rtl;


### PR DESCRIPTION
All pin changes needed for scu4.1:
- dedicated PSRAM control Pins
- Debug LEDs
- SFP rate select 
