### PR TITLE
Line in info rom shows a clean or dirty build

### DIFF
--- a/modules/build_id/build_id.tcl
+++ b/modules/build_id/build_id.tcl
@@ -63,6 +63,19 @@ lappend output "OS version  : $build_os"
 lappend output "Quartus     : $quartus(version)"
 lappend output ""
 
+set gitstatus [open "| git status --short" "r"]
+set changes ""
+while {[gets $gitstatus line] >= 0} {
+    append changes $line
+}
+close $gitstatus
+
+if {$changes eq ""} {
+    lappend output "Repository  : clean"
+} else {
+    lappend output "Repository  : dirty"
+}
+
 set gitlog [open "| git log --oneline --decorate=no -n 5" "r"]
 while {[gets $gitlog line] >= 0} { lappend output "  $line" }
 close $gitlog

--- a/modules/build_id/build_id.tcl
+++ b/modules/build_id/build_id.tcl
@@ -66,6 +66,12 @@ lappend output ""
 set gitstatus [open "| git status --short" "r"]
 set changes ""
 while {[gets $gitstatus line] >= 0} {
+    if {[regexp "^ M .*\\.qsf\$" $line]} {
+        continue
+    }
+    if {[regexp "^ M .*ramsize_pkg\\.vhd\$" $line]} {
+        continue
+    }
     append changes $line
 }
 close $gitstatus

--- a/modules/lm32-include/build_lm32.mk
+++ b/modules/lm32-include/build_lm32.mk
@@ -53,11 +53,12 @@ CBR_FLGS := $(CFLAGS)
 CBR_KRNL := `uname -mrs`
 CBR_OS   := `lsb_release -d -s | tr -d '"'` 
 CBR_PF   := $(PLATFORM)
+CBR_CLEAN := $(shell [ -z "`git status --short`" ] && echo "clean" || echo "dirty")
 CBR_GIT1  := `git log HEAD~0 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT2  := `git log HEAD~1 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT3  := `git log HEAD~2 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT4  := `git log HEAD~3 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT5  := `git log HEAD~4 --oneline --decorate=no -n 1 | cut -c1-100`
 
-CBR = "\#define BUILDID __attribute__((section(\".buildid\")))\nconst char BUILDID build_id_rom[] = \""'\\'"\nUserLM32"'\\n\\'"\nStack Status:                                                       "'\\n\\'"\nProject     : $(TARGET)"'\\n\\'"\nVersion     : $(VERSION)"'\\n\\'"\nPlatform    : $(CBR_PF)"'\\n\\'"\nBuild Date  : $(CBR_DATE)"'\\n\\'"\nPrepared by : $(USER) $(CBR_USR) <$(CBR_MAIL)>"'\\n\\'"\nPrepared on : $(CBR_HOST)"'\\n\\'"\nOS Version  : $(CBR_OS) $(CBR_KRNL)"'\\n\\'"\nGCC Version : $(CBR_GCC)"'\\n\\'"\nIntAdrOffs  : $(CONFIG_RAMADDR)"'\\n\\'"\nSharedOffs  : $(SHARED_START)"'\\n\\'"\nSharedSize  : $(SHARED_SIZE)"'\\n\\'"\nFW-ID ROM will contain:"'\\n\\n\\'"\n   $(CBR_GIT1)"'\\n\\'"\n   $(CBR_GIT2)"'\\n\\'"\n   $(CBR_GIT3)"'\\n\\'"\n   $(CBR_GIT4)"'\\n\\'"\n   $(CBR_GIT5)"'\\n\\'"\n\";\n"
+CBR = "\#define BUILDID __attribute__((section(\".buildid\")))\nconst char BUILDID build_id_rom[] = \""'\\'"\nUserLM32"'\\n\\'"\nStack Status:                                                       "'\\n\\'"\nProject     : $(TARGET)"'\\n\\'"\nVersion     : $(VERSION)"'\\n\\'"\nPlatform    : $(CBR_PF)"'\\n\\'"\nBuild Date  : $(CBR_DATE)"'\\n\\'"\nPrepared by : $(USER) $(CBR_USR) <$(CBR_MAIL)>"'\\n\\'"\nPrepared on : $(CBR_HOST)"'\\n\\'"\nOS Version  : $(CBR_OS) $(CBR_KRNL)"'\\n\\'"\nGCC Version : $(CBR_GCC)"'\\n\\'"\nIntAdrOffs  : $(CONFIG_RAMADDR)"'\\n\\'"\nSharedOffs  : $(SHARED_START)"'\\n\\'"\nSharedSize  : $(SHARED_SIZE)"'\\n\\'"\nThreadQty   : $(THR_QTY)"'\\n\\n\\'"\nRepository  : $(CBR_CLEAN)"'\\n\\'"\n   $(CBR_GIT1)"'\\n\\'"\n   $(CBR_GIT2)"'\\n\\'"\n   $(CBR_GIT3)"'\\n\\'"\n   $(CBR_GIT4)"'\\n\\'"\n   $(CBR_GIT5)"'\\n\\'"\n\";\n"
 

--- a/modules/lm32-include/build_lm32.mk
+++ b/modules/lm32-include/build_lm32.mk
@@ -44,6 +44,12 @@ GCC_BUILD = $(shell strings $(GCC_PATH) /dev/null | grep /share/locale | grep -o
 GCC_VER   := `$(CC) --version | grep gcc`
 CBR_GCC   = "$(GCC_VER) " (build " $(GCC_BUILD)")""
 
+#check git status, filter out modified qsfs and ramsize packages
+GIT_STATUS_FILTERED := $(shell \
+  git status --short | \
+  grep -vE '^ M +(\.qsf|ramsize_package\.vhd)$$' || true \
+)
+
 VERSION  ?= "1.0.0"
 CBR_DATE := `date +"%a %b %d %H:%M:%S %Z %Y"`
 CBR_USR  := `git config user.name`
@@ -53,7 +59,7 @@ CBR_FLGS := $(CFLAGS)
 CBR_KRNL := `uname -mrs`
 CBR_OS   := `lsb_release -d -s | tr -d '"'` 
 CBR_PF   := $(PLATFORM)
-CBR_CLEAN := $(shell [ -z "`git status --short`" ] && echo "clean" || echo "dirty")
+CBR_CLEAN := $(if $(strip $(GIT_STATUS_FILTERED)),dirty,clean)
 CBR_GIT1  := `git log HEAD~0 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT2  := `git log HEAD~1 --oneline --decorate=no -n 1 | cut -c1-100`
 CBR_GIT3  := `git log HEAD~2 --oneline --decorate=no -n 1 | cut -c1-100`


### PR DESCRIPTION
Info ROMs for gateware and firmware (read by eb-info) now contain a line showing if the git repository was clean or dirty, aka modified at the time of the build.
```
Info:   Prepared on : acopc050
Info:   OS version  : 6.8.0-60-generic x86_64 GNU/Linux
Info:   Quartus     : Version 18.1.0 Build 625 09/12/2018 SJ Standard Edition
Info:   
Info:   Repository  : clean
```

Changes to QSFs and ramsize_pkg.vhd' are ignored during build, as this is Quartus in action.