### PR TITLE
Simple DIOB access functionalities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,7 @@ test_run_all: test_install_dim test_build_ftm_shared_map \
 	test_b2b test_wr-mil test_wr-unipz test_dm-unipz \
 	test_uni-blm test_uni-chop \
 	test_fec_analyzer test_freq-measure test_sync-mon \
-	test_lm32_examples
+	test_lm32_examples test_fbas
 
 test_install_dim:
 	unzip -n res/dim/$(DIM_VERSION).zip -d res/dim/
@@ -882,3 +882,6 @@ test_lm32_examples:
 	$(MAKE) -C modules/lm32-example TARGET=example
 	$(MAKE) -C modules/lm32-example TARGET=milExample
 	$(MAKE) -C modules/lm32-example TARGET=milSnooper
+
+test_fbas:
+	$(MAKE) -C modules/fbas/fw

--- a/modules/fbas/fw/Makefile
+++ b/modules/fbas/fw/Makefile
@@ -8,7 +8,7 @@ export PATH          := $(PWD)/../../../toolchain/bin:$(PATH)
 # common settings
 export SHARED_SIZE   ?= 8K
 export USRCPUCLK     ?= 125000
-export VERSION       = 01.04.01
+export VERSION       = 01.04.02
 export PATHFW        = .
 export DEBUGLVL      = 2
 export EXTRA_FLAGS   ?=

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -117,6 +117,7 @@ static void cmdHandler(uint32_t *reqState, uint32_t cmd);
 static void timerHandler(void);
 static uint32_t handleEcaEvent(uint32_t pollTimeout, uint32_t* mpsTask, msgCtrl_t* pMsgCtrl, mpsMsg_t** head);
 static void wrConsolePeriodic(void);
+static void setErrorFlag(uint8_t error);
 
 /**
  * \brief init for lm32
@@ -180,6 +181,7 @@ static status_t initSharedMem(uint32_t *const sharedStart)
   DBPRINT1("fbas%d: FBAS_BAD_MSG 0x%8p (0x%8p)\n", nodeType, (pSharedApp + (FBAS_SHARED_BAD_MSG_CNT >> 2)), (pSharedExt + (FBAS_SHARED_BAD_MSG_CNT >> 2)));
   DBPRINT1("fbas%d: FBAS_SENDERID 0x%8p (0x%8p)\n", nodeType, (pSharedApp + (FBAS_SHARED_SENDERID >> 2)), (pSharedExt + (FBAS_SHARED_SENDERID >> 2)));
   DBPRINT1("fbas%d: FBAS_ACT_RATE 0x%8p (0x%8p)\n", nodeType, (pSharedApp + (FBAS_SHARED_ACT_RATE >> 2)), (pSharedExt + (FBAS_SHARED_ACT_RATE >> 2)));
+  DBPRINT1("fbas%d: FBAS_ERROR_FLAG 0x%8p (0x%8p)\n", nodeType, (pSharedApp + (FBAS_SHARED_ERROR_FLAG >> 2)), (pSharedExt + (FBAS_SHARED_ERROR_FLAG >> 2)));
 
   sbInitSharedMemory(pSharedApp);
 
@@ -651,6 +653,24 @@ static void wrConsolePeriodic(void)
   DBPRINT2("timer avg: %lli min: %lli max: %lli, call %lli\n",
             timerDbg.period.avg, timerDbg.period.min, timerDbg.period.max, (now - lastSysTime));
   lastSysTime = now;
+}
+
+/**
+ * \brief Set a given error flag
+ *
+ * An error flag is set, when function call returns an error.
+ * Error flags can be used to diagnose the function calls.
+ *
+ * \param error  Error flag
+ *
+ * \return None
+ **/
+static void setErrorFlag(uint8_t error)
+{
+  if (!pSharedApp)
+    return;
+
+  *(pSharedApp + (FBAS_SHARED_ERROR_FLAG >> 2)) |= (1 << error);
 }
 
 // clears all statistics

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -35,7 +35,7 @@
  * For all questions and ideas contact: d.beck@gsi.de
  * Last update: 22-November-2018
  ********************************************************************************************/
-#define FBAS_FW_VERSION 0x010401        // make this consistent with makefile -> export VERSION
+#define FBAS_FW_VERSION 0x010402        // make this consistent with makefile -> export VERSION
 
 // standard includes
 #include <stdio.h>

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -1000,7 +1000,7 @@ uint32_t doActionOperation(uint32_t* pMpsTask,          // MPS-relevant tasks
         now = getSysTime();
         // build & write the MPS flags represenation to the echo register of DIOB card
         flags = (uint16_t)msgRepresentMpsFlags();
-        sbWriteDiob(&flags, SBS_ECHO);
+        sbPutMpsFlags(&flags);
         measureSummarize(MSR_DIOB_DLY, now, getSysTime(), DISABLE_VERBOSITY);
       }
       break;

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -897,6 +897,7 @@ uint32_t doActionOperation(uint32_t* pMpsTask,          // MPS-relevant tasks
   uint64_t now, last;                                         // used to measure the period of the main loop
   uint16_t actionCnt = 0;                                     // counter for non-zero action tags
   uint64_t handleActionsUntil = getSysTime() + (actionTimeout << 10);  // allowed time period to handle multiple actions (main loop budget < 125 us)
+  uint16_t flags;                                             // bit-wise representation of the MPS flags
 
   status = actStatus;
 
@@ -971,6 +972,9 @@ uint32_t doActionOperation(uint32_t* pMpsTask,          // MPS-relevant tasks
             }
           }
         }
+        // build & write the MPS flags represenation to the echo register of DIOB card
+        flags = (uint16_t)msgRepresentMpsFlags();
+        sbWriteDiob(&flags, SBS_ECHO);
       }
       break;
 

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -129,7 +129,6 @@ static void init()
   discoverPeriphery();        // mini-sdb ...
   uart_init_hw();             // needed by WR console
   cpuId = getCpuIdx();
-  sbInit();                   // init the pointer to the SCU bus master
 } // init
 
 /**
@@ -679,6 +678,8 @@ uint32_t extern_entryActionConfigured()
     outPortCfg.type = IO_CFG_CHANNEL_LVDS;
     outPortCfg.total= N_OUT_LEMO_PEXARIA;
   }
+
+  sbInit(); // probe SCU bus
 
   // app specific IO setup (TX: B2 as input, all output disabled)
   fwlib_ioCtrlSetGate(0, 2);        // disable input gate

--- a/modules/fbas/fw/fbas.c
+++ b/modules/fbas/fw/fbas.c
@@ -858,6 +858,10 @@ static void cmdHandler(uint32_t *reqState, uint32_t cmd)
         measurePrintSummary(MSR_ML_PRD);
         measureExportSummary(MSR_ML_PRD, pSharedApp, FBAS_SHARED_GET_AVG);
         break;
+      case FBAS_CMD_PRINT_DIOB_DLY:
+        measurePrintSummary(MSR_DIOB_DLY);
+        measureExportSummary(MSR_DIOB_DLY, pSharedApp, FBAS_SHARED_GET_AVG);
+        break;
       case FBAS_CMD_PRINT_ACT_RATE:
         measureExportActionRate((pSharedApp + (FBAS_SHARED_ACT_RATE >> 2)));
         break;
@@ -993,9 +997,11 @@ uint32_t doActionOperation(uint32_t* pMpsTask,          // MPS-relevant tasks
             }
           }
         }
+        now = getSysTime();
         // build & write the MPS flags represenation to the echo register of DIOB card
         flags = (uint16_t)msgRepresentMpsFlags();
         sbWriteDiob(&flags, SBS_ECHO);
+        measureSummarize(MSR_DIOB_DLY, now, getSysTime(), DISABLE_VERBOSITY);
       }
       break;
 

--- a/modules/fbas/fw/measure.h
+++ b/modules/fbas/fw/measure.h
@@ -45,6 +45,7 @@ typedef enum MSR_ITEMS {
   MSR_MSG_DLY, // messaging delay
   MSR_TTL,     // TTL threshold/interval
   MSR_ML_PRD,  // period of the main loop
+  MSR_DIOB_DLY,// DIOB access delay
   N_MSR_ITEMS,
 } msrItem_t;
 

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -294,7 +294,7 @@ void exportSbSlaveConfig(volatile uint16_t* pMaster, const uint32_t sbSlaves)
     u32val = (sbSlaves >> i) & 0x01;
 
     if (u32val) {
-      u32val <<= 16;                   // offset for a SCU bus slave
+      u32val <<= 16;                 // offset of a SCU bus slot
       pSlave = pMaster + u32val;     // address of slave device on the SCU bus
 
       retval = readSbSlaveReg(pSlave, &regSet[DIOB_CFG], configDiob);  // get the DIOB configuration
@@ -359,4 +359,39 @@ void sbCmdHandler(const uint32_t cmd)
   } else {
     DBPRINT1("sbctl: invalid CIDs (sys=%x, grp=%x)\n", cid_sys_id, cid_grp_id);
   }
+}
+
+/**
+ * \brief Write data to a given DIOB register
+ *
+ * 16-bit data contains the current PC signal state from 16 emitters.
+ * - "0"=OK, "1"=NOK
+ * - bit0 is for emitter1 (or channel1)
+ *
+ * \param pData   Pointer to the 16-bit data buffer
+ * \param reg     given DIOB register (offset)
+ *
+ * \return status Returns zero on success, otherwise non-zero
+ **/
+status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg)
+{
+  int i;
+  uint32_t u32val;
+  volatile uint16_t *pDiob;
+
+  if (!pData || !sbDiobs)
+    return COMMON_STATUS_ERROR;
+
+  for (int i = 1; i < N_SB_SLOTS; ++i) {
+    u32val = (sbDiobs >> i) & 0x01;
+
+    if (u32val) {
+      u32val <<= 16;                 // offset of a current SCU bus slot
+      pDiob = pSbMaster + u32val;    // address of a DIOB on the SCU bus
+
+      *(pDiob + reg) = *pData;       // write data to the given DIOB register
+    }
+  }
+
+  return COMMON_STATUS_OK;
 }

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -215,8 +215,11 @@ status_t probeSbSlaves(volatile uint16_t* pMaster, uint16_t sysId, uint16_t grpI
   int slot;
   uint16_t cidSys, cidGrp, u16val;
 
-  if (!pMaster || !slaves || !sysId || !grpId)
+  if (!pMaster || !slaves || !sysId || !grpId) {
+    DBPRINT1("sbctl: bad arguments to probe SCU bus slaves: 0x%08x, 0x%04x, 0x%04x, 0x%08x\n",
+      pMaster, sysId, grpId, slaves);
     return COMMON_STATUS_ERROR;
+  }
 
   for (slot = 1; slot <= N_SB_SLOTS; slot++) {
     cidSys = *(pMaster + (slot << 16) + SBS_CID_SYS); // get CID system ID of a SCU bus slave

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -384,7 +384,7 @@ status_t writeDiobReg(const uint16_t data, const uint16_t reg)
   if (!sbDiobs)
     return COMMON_STATUS_ERROR;
 
-  for (int i = 1; i < N_SB_SLOTS; ++i) {
+  for (int i = 1; i <= N_SB_SLOTS; ++i) {
     u32val = (sbDiobs >> i) & 0x01;
 
     if (u32val) {

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -80,6 +80,7 @@ status_t writeSbSlaveReg(volatile uint16_t* pSlave, regset_t* regset, uint16_t *
 status_t probeSbSlaveExt(volatile uint16_t* pMaster, uint32_t slot, uint32_t* pDst);
 status_t probeSbSlaves(volatile uint16_t* pMaster, uint16_t sysId, uint16_t grpId, uint32_t* slaves);
 void exportSbSlaveConfig(volatile uint16_t* pMaster, const uint32_t sbSlaves);
+status_t writeDiobReg(const uint16_t data, const uint16_t reg);
 
 /**
  * \brief Initialize the pointer to the SCU bus master
@@ -97,6 +98,9 @@ void sbInit(void)
 
   // probe all DIOB cards
   probeSbSlaves(pSbMaster, CID_SYS_DIOB, CID_GRP_DIOB, &sbDiobs);
+
+  // init the DIOB echo register
+  writeDiobReg(0, SBS_ECHO);
 }
 
 /**
@@ -366,22 +370,18 @@ void sbCmdHandler(const uint32_t cmd)
 /**
  * \brief Write data to a given DIOB register
  *
- * 16-bit data contains the current PC signal state from 16 emitters.
- * - "0"=OK, "1"=NOK
- * - bit0 is for emitter1 (or channel1)
- *
- * \param pData   Pointer to the 16-bit data buffer
- * \param reg     given DIOB register (offset)
+ * \param data   16-bit data
+ * \param reg    DIOB register (offset)
  *
  * \return status Returns zero on success, otherwise non-zero
  **/
-status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg)
+status_t writeDiobReg(const uint16_t data, const uint16_t reg)
 {
   int i;
   uint32_t u32val;
   volatile uint16_t *pDiob;
 
-  if (!pData || !sbDiobs)
+  if (!sbDiobs)
     return COMMON_STATUS_ERROR;
 
   for (int i = 1; i < N_SB_SLOTS; ++i) {
@@ -390,8 +390,34 @@ status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg)
     if (u32val) {
       pDiob = pSbMaster + (i << 16); // DIOB base address on the SCU bus
 
-      *(pDiob + reg) = *pData;       // write data to the given DIOB register
+      *(pDiob + reg) = data;         // write data to the given DIOB register
     }
+  }
+
+  return COMMON_STATUS_OK;
+}
+
+/**
+ * \brief Send the bit-wise MPS flags to a dedicated DIOB register
+ *
+ * MPS flags are represented in 16-bit data, where each bit corresponds
+ * to the current PC signal state from its emitter.
+ * - "0"=OK, "1"=NOK
+ * - bit0 is for emitter1 (or channel1)
+ *
+ * The dedicated DIOB register is updated only in case of new MPS flags.
+ *
+ * \param pData   Pointer to the 16-bit data source
+ *
+ * \return status Returns zero on success, otherwise non-zero
+ **/
+status_t sbPutMpsFlags(const uint16_t* pData)
+{
+  static uint16_t flags = 0xff;
+
+  if (flags != *pData) {
+    flags = *pData;
+    return writeDiobReg(flags, SBS_ECHO);
   }
 
   return COMMON_STATUS_OK;

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -414,8 +414,10 @@ status_t writeDiobReg(const uint16_t data, const uint16_t reg)
 status_t sbPutMpsFlags(const uint16_t* pData)
 {
   static uint16_t flags = 0xff;
+  static uint8_t initialized = 0;
 
-  if (flags != *pData) {
+  if (!initialized || flags != *pData) {
+    initialized = 1;
     flags = *pData;
     return writeDiobReg(flags, SBS_ECHO);
   }

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -297,8 +297,7 @@ void exportSbSlaveConfig(volatile uint16_t* pMaster, const uint32_t sbSlaves)
     u32val = (sbSlaves >> i) & 0x01;
 
     if (u32val) {
-      u32val <<= 16;                 // offset of a SCU bus slot
-      pSlave = pMaster + u32val;     // address of slave device on the SCU bus
+      pSlave = pMaster + (i << 16);  // slave base address on the SCU bus
 
       retval = readSbSlaveReg(pSlave, &regSet[DIOB_CFG], configDiob);  // get the DIOB configuration
       retval |= readSbSlaveReg(pSlave, &regSet[DIOB_STS], statusDiob);  // get the DIOB status
@@ -389,8 +388,7 @@ status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg)
     u32val = (sbDiobs >> i) & 0x01;
 
     if (u32val) {
-      u32val <<= 16;                 // offset of a current SCU bus slot
-      pDiob = pSbMaster + u32val;    // address of a DIOB on the SCU bus
+      pDiob = pSbMaster + (i << 16); // DIOB base address on the SCU bus
 
       *(pDiob + reg) = *pData;       // write data to the given DIOB register
     }

--- a/modules/fbas/fw/sbctl.c
+++ b/modules/fbas/fw/sbctl.c
@@ -47,6 +47,7 @@ uint32_t *pSharedGetSbStd;              // "user defined" u32 reg: standard regi
 
 // SCU bus specific variables
 uint32_t sbSlaves = 0;                  // SCU bus slaves (bit1=slot1)
+uint32_t sbDiobs = 0;                   // DIOB cards in SCU bus (bit1=slot1)
 uint16_t configDiob[N_DIOB_CFG] = {0};  // configuration registers of DIOB
 uint16_t statusDiob[N_DIOB_STS] = {0};  // status registers of DIOB
 uint16_t configUser[N_USR_CFG] = {0};   // configuration registers of user interface (extension) card
@@ -93,6 +94,9 @@ void sbInit(void)
 {
   // init the SCU bus master
   pSbMaster = (uint16_t*)fwlib_getSbMaster();
+
+  // probe all DIOB cards
+  probeSbSlaves(pSbMaster, CID_SYS_DIOB, CID_GRP_DIOB, &sbDiobs);
 }
 
 /**

--- a/modules/fbas/fw/sbctl.h
+++ b/modules/fbas/fw/sbctl.h
@@ -144,5 +144,6 @@ typedef struct regset {
 void     sbInit(void);
 void     sbInitSharedMemory(const uint32_t* pSharedApp);
 void     sbCmdHandler(const uint32_t cmd);
+status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg);
 
 #endif

--- a/modules/fbas/fw/sbctl.h
+++ b/modules/fbas/fw/sbctl.h
@@ -144,6 +144,6 @@ typedef struct regset {
 void     sbInit(void);
 void     sbInitSharedMemory(const uint32_t* pSharedApp);
 void     sbCmdHandler(const uint32_t cmd);
-status_t sbWriteDiob(const uint16_t* pData, const uint16_t reg);
+status_t sbPutMpsFlags(const uint16_t* pData);
 
 #endif

--- a/modules/fbas/fw/tmessage.c
+++ b/modules/fbas/fw/tmessage.c
@@ -532,3 +532,34 @@ void ioPrintMpsBuf(void)
         bufMpsMsg[i].ttl,
         bufMpsMsg[i].pending);
 }
+
+/**
+ * \brief Build a bit-wise representation of the MPS flags
+ *
+ * Build a simple data representing the current MPS flags.
+ * MPS flags are stored in the MPS message buffer.
+ * Each bit represents a MPS flag from each emitter:
+ * - bit 0 corresponds to emitter 1
+ * - logic 1 = NOK, logic 0 = OK
+ *
+ * Up to 16 TX nodes are supported, then lower 16 bits are
+ * effectively present the MPS flags.
+ *
+ * \return Returns data representing the MPS flags
+ *
+ **/
+uint32_t msgRepresentMpsFlags(void)
+{
+  int i, j, step = 1;
+  uint32_t flags = 0;
+
+  if (N_MAX_MPS_CHANNELS != N_MAX_TX_NODES)
+    step = N_MPS_CHANNELS; // 8 channels for each node
+
+  for (i = 0, j = 0; i < N_MAX_MPS_CHANNELS; i+=step, j++) {
+    if (bufMpsMsg[i].prot.flag == MPS_FLAG_NOK)
+      flags|= (1 << j);
+  }
+
+  return flags;
+}

--- a/modules/fbas/fw/tmessage.h
+++ b/modules/fbas/fw/tmessage.h
@@ -87,5 +87,6 @@ status_t  msgRegisterNode(const uint64_t id, const regCmd_t cmd, const uint8_t i
 int8_t    msgGetNodeIndex(const uint64_t *pId);
 
 void      ioPrintMpsBuf(void);
+uint32_t  msgRepresentMpsFlags(void);
 
 #endif

--- a/modules/fbas/include/fbas.h
+++ b/modules/fbas/include/fbas.h
@@ -76,7 +76,8 @@
 #define FBAS_SHARED_ML_PRD_VLD     (FBAS_SHARED_ML_PRD_MAX     + 2 * _32b_SIZE_)   // valid count
 #define FBAS_SHARED_ML_PRD_ALL     (FBAS_SHARED_ML_PRD_VLD     + _32b_SIZE_)       // all/total count
 #define FBAS_SHARED_ACT_RATE       (FBAS_SHARED_ML_PRD_ALL     + _32b_SIZE_)       // buffer for 8 elements
-#define FBAS_SHARED_END            (FBAS_SHARED_ACT_RATE       + 8 * _32b_SIZE_)   // end of the app-spec region
+#define FBAS_SHARED_ERROR_FLAG     (FBAS_SHARED_ACT_RATE       + 8 * _32b_SIZE_)   // error flag
+#define FBAS_SHARED_END            (FBAS_SHARED_ERROR_FLAG     + _32b_SIZE_)       // end of the app-spec region
 
 // valid value for data fields in the MPS payload
 #define MPS_VID_FBAS     105   // VLAN ID for FBAS

--- a/modules/fbas/include/fbas.h
+++ b/modules/fbas/include/fbas.h
@@ -131,6 +131,7 @@ typedef enum {
 #define FBAS_CMD_PRINT_ML_PRD   0x3a   // print result of the main loop period measurement
 #define FBAS_CMD_PRINT_ACT_RATE 0x3b   // print the action rate
 #define FBAS_CMD_SET_TX_RATE    0x3c   // set the TX messaging rate
+#define FBAS_CMD_PRINT_DIOB_DLY 0x3d   // print the measurement results of the DIOB access delay
 
 // mask bit for MPS-relevant tasks (up to 31)
 #define TSK_TX_MPS_FLAGS        0x10000000 // transmit MPS flags

--- a/modules/fbas/test/scu/setup_local.sh
+++ b/modules/fbas/test/scu/setup_local.sh
@@ -121,6 +121,7 @@ export instr_st_ttl_ival=0x35   # store the TTL interval measurement results to 
 export instr_st_eca_dly=0x37    # store the measurement result of the ECA handling delay
 export instr_st_rx_dly=0x39     # store the RX handler delay measurement results to shared memory
 export instr_st_ml_prd=0x3a     # store the main loop period measurement results to shared memory
+export instr_st_diob_dly=0x3d   # store the DIOB access delay measurement results to the shared memory
 export instr_st_array=0x3b      # store the uint32_t array[8] to the reserved location of the shared memory
 export instr_set_tx_rate=0x3c   # set the TX messaging rate: FBAS_CMD_SET_TX_RATE
 
@@ -750,6 +751,16 @@ result_ml_period() {
         echo -n "loop prd: "
     fi
     read_measurement_results $1 $instr_st_ml_prd $addr_avg $2
+}
+
+result_diob_delay() {
+    # $1 - dev/wbm0
+    # $2 - verbosity
+
+    if [ -n "$2" ]; then
+        echo -n "DIOB dly: "
+    fi
+    read_measurement_results $1 $instr_st_diob_dly $addr_avg $2
 }
 
 result_rx() {

--- a/modules/fbas/test/tools/measure_ttf_rx_rate.sh
+++ b/modules/fbas/test/tools/measure_ttf_rx_rate.sh
@@ -69,13 +69,14 @@ format_measurements() {
 
     # delays
     line+="\t--- delays, us (avg, min, max, valid, all)\n"
-    line+="\tECA delay  : ${output[@]:25:5}\n" # get 5 elements starting at index 25
+    line+="\tECA delay  : ${output[@]:30:5}\n" # get 5 elements starting at index 30
     line+="\tRX delay   : ${output[@]:5:5}\n"  # get 5 elements starting at index 5
     line+="\tMsg delay  : ${output[@]:10:5}\n" # get 5 elements starting at index 10
+    line+="\tDIOB delay : ${output[@]:25:5}\n" # get 5 elements starting at index 25
     line+="\tTTL period : ${output[@]:15:5}\n" # get 5 elements starting at index 15
     line+="\tLoop period: ${output[@]:20:5}\n" # get 5 elements starting at index 20
     line+="\t--- action handling rate\n"
-    line+="\t${output[@]:30:8}\n"              # get 8 elements starting at index 30
+    line+="\t${output[@]:35:8}\n"              # get 8 elements starting at index 35
 
     ret="$line"
 }

--- a/modules/fbas/test/tools/measure_ttf_rx_rate.sh
+++ b/modules/fbas/test/tools/measure_ttf_rx_rate.sh
@@ -38,6 +38,7 @@ get_tr_measurements() {
     result_msg_delay \$rx_node_dev && \
     result_ttl_ival \$rx_node_dev && \
     result_ml_period \$rx_node_dev && \
+    result_diob_delay \$rx_node_dev && \
     result_eca_delay \$rx_node_dev && \
     read_array \$rx_node_dev 8")
     ret_code=$?

--- a/modules/fbas/test/tools/test_ttf_nw_perf.sh
+++ b/modules/fbas/test/tools/test_ttf_nw_perf.sh
@@ -218,6 +218,7 @@ measure_nw_perf() {
         result_rx_delay \$rx_node_dev $verbose && \
         result_msg_delay \$rx_node_dev $verbose && \
         result_ml_period \$rx_node_dev $verbose && \
+        result_diob_delay \$rx_node_dev $verbose && \
         result_ttl_ival \$rx_node_dev $verbose" |
     while IFS= read -r line; do
         delay_entry="${rx_delay_entries[$i]}"


### PR DESCRIPTION
On reception of new PC flags, a collector node should write them to the dedicated DIOB register.
Access to the DIOB is via the SCU bus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DIOB access delay measurement reporting.
  * Added a new command to print and export DIOB delay results.
  * Improved handling of MPS flag updates so DIOB echo output updates only when values change.

* **Improvements**
  * Enhanced shared-memory error diagnostics with an additional error flag and more informative startup output.

* **Chores**
  * Firmware version updated to **01.04.02**.
  * Expanded test coverage to include the FBAS firmware build/tests and added DIOB delay measurements to relevant test outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->