### PR TITLE
add uart1 to neorv sim

### DIFF
--- a/modules/neorv32/sim/hdl/neorv32_tb_slim.vhd
+++ b/modules/neorv32/sim/hdl/neorv32_tb_slim.vhd
@@ -18,6 +18,8 @@ architecture rtl of neorv32_tb_slim is
   signal s_clk      : std_logic;
   signal s_rstn     : std_logic;
   signal s_uart_out : std_logic := '0';
+  signal s_uart0_in : std_logic;
+  signal s_uart1_in : std_logic;
 
   signal s_dummy_slave_i  : t_wishbone_slave_in := cc_dummy_slave_in;
   signal s_dummy_slave_o  : t_wishbone_slave_out := cc_dummy_slave_out;
@@ -63,7 +65,9 @@ begin
     slave_o    => s_dummy_slave_o,
     master_i   => s_dummy_master_i,
     master_o   => s_dummy_master_o,
-    uart_o     => s_uart_out,
+    uart0_o    => s_uart_out,
+    uart0_i    => s_uart0_in,
+    uart1_i    => s_uart1_in,
     jtag_tck_i => '0',
     jtag_tdi_i => '0',
     jtag_tdo_o => open,

--- a/modules/neorv32/sim/hdl/neorv32_tb_xbar.vhd
+++ b/modules/neorv32/sim/hdl/neorv32_tb_xbar.vhd
@@ -20,6 +20,8 @@ architecture rtl of neorv32_tb_xbar is
   signal s_gpio_out : std_logic_vector(31 downto 0);
   signal s_gpio_in  : std_logic_vector(31 downto 0);
   signal s_uart_out : std_logic := '0';
+  signal s_uart0_in : std_logic;
+  signal s_uart1_in : std_logic;
 
   signal s_dummy_slave_i  : t_wishbone_slave_in := cc_dummy_slave_in;
   signal s_dummy_slave_o  : t_wishbone_slave_out := cc_dummy_slave_out;
@@ -80,7 +82,9 @@ begin
     slave_o    => s_dummy_slave_o,
     master_i   => cbar_slave_o(0),
     master_o   => cbar_slave_i(0),
-    uart_o     => s_uart_out,
+    uart0_o    => s_uart_out,
+    uart0_i    => s_uart0_in,
+    uart1_i    => s_uart1_in,
     jtag_tck_i => '0',
     jtag_tdi_i => '0',
     jtag_tdo_o => open,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation UART wiring so the testbench now handles separate UART0 and UART1 connections correctly.
  * Updated the simulator setup to better reflect multi-UART behavior, helping avoid mismatches during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->